### PR TITLE
✨ [CW-23314] feat: add Core Blockchain Config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coolbitx/blockchain-info",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@coolbitx/blockchain-info",
-      "version": "0.0.22",
+      "version": "0.0.23",
       "license": "ISC",
       "dependencies": {
         "@types/node": "^17.0.27",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolbitx/blockchain-info",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "description": "Blockchain Information",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ export enum Network {
   TON = "TON",
   KASPA = "Kaspa",
   SUI = "Sui",
+  CORE = 'Core',
 }
 
 const EvmChainIdList: Record<string, number> = {
@@ -63,6 +64,7 @@ const EvmChainIdList: Record<string, number> = {
   [Network.Linea]: 59144,
   [Network.Base]: 8453,
   [Network.Dis]: 513100,
+  [Network.CORE]: 1116,
 };
 
 export function getEvmChainIdByNetwork(network: Network): number {
@@ -243,6 +245,10 @@ export const CoinMap: { [key: string]: { name: Network; symbol: string } } = {
   SUI: {
     name: Network.SUI,
     symbol: "SUI",
+  },
+  CORE: {
+    name: Network.CORE,
+    symbol: "CORE",
   },
 };
 


### PR DESCRIPTION
https://docs.coredao.org/docs/Dev-Guide/core-mainnet-wallet-config
 
 **PR Summary by Typo**
------------

**Overview**
This PR adds configuration for the Core blockchain to the project.  This includes adding Core to the Network enum, assigning it a chain ID, and adding it to the CoinMap.

**Key Changes**
- Added `CORE` to the `Network` enum.
- Assigned chain ID 1116 to `Network.CORE`.
- Added a `CORE` entry to the `CoinMap` with the symbol "CORE".
- Updated package version to 0.0.23.

**Recommendations**
Ready to merge after verifying the correctness of the Core chain ID and ensuring the new configuration doesn't introduce any conflicts or regressions.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>